### PR TITLE
Fix broken links to GitHub CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,17 @@ When creating a new repository, make sure to select this repository as a reposit
 
 Enter your repository-specific configuration
 - Replace the "Package.swift", "Sources" and "Tests" folder with your Swift Package
-- Enter your project name instead of "ApodiniTemplate" in .jazzy.yml
 - Enter the correct Swift Package name (currently "ApodiniTemplate") in the pull_request.yml and release.yml files.
 - Update the DocC documentation to reflect the name of the new Swift package and adapt the docs and build and test GitHub Actions where the documentation is generated to the updated names to be sure the DocC generation works as expected 
 - Update the README with your information and replace the links to the license with the new repository.
-- Update the status badges to point to the GitHub actions of your repository
+- Update the status badges to point to the GitHub actions of your repository.
 - If you create a new repository in the Apodini organization, you do not need to add a personal access token named "ACCESS_TOKEN". If you create the repo outside the Apodini organization, you need to create such a token with write access to the repo for all GitHub Actions to work. You will need to give the `ApodiniBot` user write access to the repository.
 
 ### ⬆️ Remove everything up to here ⬆️
 
 # Project Name
 
-[![REUSE Compliance Check](https://github.com/Apodini/Template-Repository/actions/workflows/reuseaction.yml/badge.svg)](https://github.com/Apodini/Template-Repository/actions/workflows/reuseaction.yml)
-[![Build and Test](https://github.com/Apodini/Template-Repository/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/Apodini/Template-Repository/actions/workflows/build-and-test.yml)
+[![Build](https://github.com/Apodini/Template-Repository/actions/workflows/build.yml/badge.svg)](https://github.com/Apodini/Template-Repository/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/Apodini/Template-Repository/branch/develop/graph/badge.svg?token=5MMKMPO5NR)](https://codecov.io/gh/Apodini/Template-Repository)
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When creating a new repository, make sure to select this repository as a reposit
 
 Enter your repository-specific configuration
 - Replace the "Package.swift", "Sources" and "Tests" folder with your Swift Package
-- Enter the correct Swift Package name (currently "ApodiniTemplate") in the pull_request.yml and release.yml files.
+- Enter the correct Swift Package name (currently "ApodiniTemplate") in the build.yml, pull_request.yml and release.yml files.
 - Update the DocC documentation to reflect the name of the new Swift package and adapt the docs and build and test GitHub Actions where the documentation is generated to the updated names to be sure the DocC generation works as expected 
 - Update the README with your information and replace the links to the license with the new repository.
 - Update the status badges to point to the GitHub actions of your repository.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ Enter your repository-specific configuration
 Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) first.
 
 ## License
-This project is licensed under the MIT License. See [License](https://github.com/Apodini/Template-Repository/blob/develop/LICENSE) for more information.
+This project is licensed under the MIT License. See [Licenses](https://github.com/Apodini/Template-Repository/tree/develop/LICENSES) for more information.


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix broken links to GitHub CI badges

## :recycle: Current situation & Problem

Due to the latest refactoring, the GitHub CI badges in the `README.md` are broken.

## :bulb: Proposed solution
Update the links to the new workflows. Note that the REUSE action isn't it's own workflow anymore (it is integrated into the PR workflow), therefore this badge was dropped.

## :gear: Release Notes 
Fixes broken GitHub CI badges.

## :heavy_plus_sign: Additional Information

This PR additionally removes an outdated note in regard to jazzy.

### Related PRs
--

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
