### PR TITLE
Change Update Interval to Once a Month

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ name: Update
 
 on:
   schedule:
-    - cron:  '0 0 * * 1'
+    - cron:  '0 0 1 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Change Update Interval to Once a Month

## :recycle: Current situation & Problem
The update workflow currently runs once a week. We should change this to once a month as a default value. 

## :bulb: Proposed solution
The update workflow to run once a month.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
